### PR TITLE
Explicitly requiring erb.

### DIFF
--- a/lib/easy_config/config_file.rb
+++ b/lib/easy_config/config_file.rb
@@ -1,3 +1,5 @@
+require 'erb'
+
 class EasyConfig::ConfigFile
   attr_reader :name
 


### PR DESCRIPTION
Some sinatra apps doesn't make use of erb, therefore it was not required anywhere.